### PR TITLE
lua/nvim-goc.lua: use '%:.' to ensure relative

### DIFF
--- a/lua/nvim-goc.lua
+++ b/lua/nvim-goc.lua
@@ -104,7 +104,11 @@ M.Coverage = function(fn, html)
       local lines = vim.api.nvim_eval('readfile("' .. tmp .. '")')
       for i = 2,#lines do
         local path = string.gmatch(lines[i], '(.+):')()
-        if string.find(path, relativeFile) then
+	-- For every line in the coverage output, look for the current relative
+	-- 'path/to/foo.go' (and not /abs/path/to/foo.go or ./path/to/foo.go).
+	-- This must use 'vim.fn.expand("%:.")' when calculating relativeFile
+	-- for this to work.
+	if path:sub(-#relativeFile) == relativeFile then
           local marks = string.gmatch(string.gsub(lines[i], '[^:]+:', ''), '%d+')
 
           local startline = math.max(tonumber(marks()) - 1, 0)

--- a/lua/nvim-goc.lua
+++ b/lua/nvim-goc.lua
@@ -44,7 +44,9 @@ M.Coverage = function(fn, html)
   local fullPathFile = string.gsub(vim.api.nvim_buf_get_name(0), "_test", "")
   local bufnr = vim.uri_to_bufnr("file://" .. fullPathFile)
 
-  local relativeFile = string.gsub(vim.fn.expand('%'), "_test", "")
+  -- use '%:.' to ensure the current path is relative (required for matching
+  -- coverage output)
+  local relativeFile = string.gsub(vim.fn.expand('%:.'), "_test", "")
   local package = vim.fn.expand('%:p:h')
   local tmp = vim.api.nvim_eval('tempname()')
 


### PR DESCRIPTION
Prior to this change, opening a file in netrw would cause '%' to be an absolute path, thus breaking `string.find(path, relativeFile)`. With this change, we can ensure it is relative before and after netrw. The first commit makes this change and fully addresses the issue.

With the first commit in place, the optional second commit allows us to be more precise with our match. `string.find(path, relativeFile)` works because `path` is `/abs/path/to/foo.go` and `relativeFile` is `path/to/foo.go` (before the first commit, `relativeFile` was `./path/to/foo.go` which matches since `.` matches any character). `string.find()` isn't limited to ending with `path` so it's possible that `string.find()` could match `/abs/foo.go/path/to/somthing/else.go`. With the first commit using `%:.`, `relativePath` omits the `./` prefix (tested on nvim 0.6.1) giving us the opportunity to check the end of the string with `path:sub(-#relativeFile) == relativeFile` instead.

Please consider taking at least the first commit to fix a real issue that exists today. Thanks for writing this! :)

References:
* :help expand
* :help fnamemodify
* :help filename-modifiers