### PR TITLE
Replace soon-to-be-deprecated highlight-link syntax with vim.api

### DIFF
--- a/lua/nvim-goc.lua
+++ b/lua/nvim-goc.lua
@@ -24,9 +24,10 @@ M.Show = function()
 end
 
 M.setup = function(opts)
-  vim.highlight.link('GocNormal', 'Comment')
-  vim.highlight.link('GocCovered', 'String')
-  vim.highlight.link('GocUncovered', 'Error')
+  -- setting highlight groups globally (0), linked to defaults
+  vim.api.nvim_set_hl(0, 'GocNormal', {link = 'Comment'})
+  vim.api.nvim_set_hl(0, 'GocCovered', {link = 'String'})
+  vim.api.nvim_set_hl(0, 'GocUncovered', {link = 'Error'})
 
   if opts then
       verticalSplit = opts.verticalSplit or false


### PR DESCRIPTION
Recent 0.8-... versions warn:

    vim.highlight.link is deprecated, use vim.api.nvim_set_hl instead. See :h deprecated
    This function will be removed in Nvim version 0.9

Accordingly, this replaces the syntax.

For the new function, see 'nvim_set_hl' in `:h api.txt`.

---

Clearly, once nvim 0.9 is released this is necessary to account for.

If this should try to support both and perform some version check, feel free to edit the PR. (same for other changes) :)