### PR TITLE
fix: update nvim-treesitter API usage

### DIFF
--- a/lua/nvim-goc.lua
+++ b/lua/nvim-goc.lua
@@ -190,7 +190,7 @@ end
 
 M.CoverageFunc = function(p, html, customArgs)
   if not p then
-    p = ts.get_node_at_cursor()
+    p = ts.get_node()
     if not p then
       print("[goc] no test function found")
       return

--- a/lua/nvim-goc.lua
+++ b/lua/nvim-goc.lua
@@ -1,4 +1,4 @@
-local ts_utils = require "nvim-treesitter.ts_utils"
+local ts = vim.treesitter
 
 local M = {
   hi = vim.api.nvim_create_namespace("goc"),
@@ -190,7 +190,7 @@ end
 
 M.CoverageFunc = function(p, html, customArgs)
   if not p then
-    p = ts_utils.get_node_at_cursor()
+    p = ts.get_node_at_cursor()
     if not p then
       print("[goc] no test function found")
       return
@@ -204,7 +204,7 @@ M.CoverageFunc = function(p, html, customArgs)
     end
     return M.CoverageFunc(p, html, customArgs)
   end
-  return M.Coverage(string.gmatch(ts_utils.get_node_text(p)[1], 'Test[^%s%(]+')(), html, customArgs)
+  return M.Coverage(string.gmatch(ts.get_node_text(p, 1), 'Test[^%s%(]+')(), html, customArgs)
 end
 
 M.ClearCoverage = function(bufnr)


### PR DESCRIPTION
### PR Summary

This pull request updates the `nvim-goc` plugin to align with recent changes in the `nvim-treesitter` API. Specifically, it replaces deprecated `nvim-treesitter.ts_utils` module calls with direct `vim.treesitter` functions, ensuring compatibility with newer versions of `nvim-treesitter`.

### Affected Modules

* `lua/nvim-goc.lua`

### Key Details

* Replaces `require "nvim-treesitter.ts_utils"` with `local ts = vim.treesitter`.
* Updates `ts_utils.get_node_at_cursor()` to `ts.get_node_at_cursor()`.
* Changes `ts_utils.get_node_text(p)[1]` to `ts.get_node_text(p, 1)`.
* Addresses the breaking change introduced in `nvim-treesitter` where `ts_utils` was deprecated.

### Potential Impacts

* This change is necessary for the plugin to function correctly with recent versions of `nvim-treesitter`.
* Users on older `nvim-treesitter` versions might experience issues if `vim.treesitter` functions are not available or behave differently.
* **Backward Compatibility Concern:** It is recommended to consider tagging releases for different `nvim-treesitter` versions to maintain compatibility for users who cannot update `nvim-treesitter`.

### Breaking Changes

* This PR itself fixes a breaking change from `nvim-treesitter`. However, this fix might introduce incompatibility with old `nvim-treesitter` versions that do not have the `vim.treesitter` API or have different function signatures.